### PR TITLE
refactor: 前端页面按多源/单源/任务管理拆分

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",
-    "type-check": "vue-tsc --build"
+    "type-check": "vue-tsc --build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@types/leaflet": "^1.9.21",
@@ -32,14 +34,17 @@
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^24.10.9",
     "@vitejs/plugin-vue": "^6.0.3",
+    "@vue/test-utils": "^2.4.10",
     "@vue/tsconfig": "^0.8.1",
     "autoprefixer": "^10.4.24",
+    "jsdom": "^29.1.1",
     "npm-run-all2": "^8.0.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-vue-devtools": "^8.0.5",
+    "vitest": "^4.1.5",
     "vue-tsc": "^3.2.2"
   },
   "engines": {

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -46,11 +46,23 @@
           </svg>
           禁飞区
         </router-link>
-        <router-link to="/error-analysis" class="nav-item" active-class="active">
+        <router-link to="/error-analysis/multi-source" class="nav-item" active-class="active">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
           </svg>
-          误差分析
+          多源分析
+        </router-link>
+        <router-link to="/error-analysis/single-source" class="nav-item" active-class="active">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+          </svg>
+          单源分析
+        </router-link>
+        <router-link to="/error-analysis/tasks" class="nav-item" active-class="active">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+          </svg>
+          任务管理
         </router-link>
       </nav>
 

--- a/frontend/src/components/errorAnalysis/AlgorithmSelector.vue
+++ b/frontend/src/components/errorAnalysis/AlgorithmSelector.vue
@@ -135,12 +135,18 @@ import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
 import { algorithmsApi } from '@/api/errorAnalysis/algorithms'
 import type { AlgorithmInfo, AlgorithmConfigSchema } from '@/types/errorAnalysis/algorithms'
 
+type AlgorithmMode = 'all' | 'multi_source' | 'single_source'
+
+const SINGLE_SOURCE_ALGORITHMS = ['kalman', 'particle_filter', 'spline']
+
 interface Props {
   disabled?: boolean
+  mode?: AlgorithmMode
 }
 
 const props = withDefaults(defineProps<Props>(), {
   disabled: false,
+  mode: 'all',
 })
 
 const emit = defineEmits<{
@@ -157,8 +163,16 @@ const localConfig = ref<Record<string, any>>({})
 const arrayInputs = ref<Record<string, string>>({})
 const loading = ref(false)
 
-// 计算属性
-const algorithms = computed(() => store.availableAlgorithms)
+const algorithms = computed(() => {
+  const all = store.availableAlgorithms
+  if (props.mode === 'multi_source') {
+    return all.filter(a => !SINGLE_SOURCE_ALGORITHMS.includes(a.name))
+  }
+  if (props.mode === 'single_source') {
+    return all.filter(a => SINGLE_SOURCE_ALGORITHMS.includes(a.name))
+  }
+  return all
+})
 const selectedAlgorithmInfo = computed(() =>
   algorithms.value.find(a => a.name === localSelectedAlgorithm.value)
 )

--- a/frontend/src/components/errorAnalysis/ErrorConfigPanel.vue
+++ b/frontend/src/components/errorAnalysis/ErrorConfigPanel.vue
@@ -27,6 +27,7 @@
     <div v-if="currentStep === 0" class="step-content">
       <AlgorithmSelector
         :disabled="store.isTaskRunning"
+        :mode="algorithmMode"
         @update:algorithm="handleAlgorithmChange"
         @update:config="handleAlgorithmConfigChange"
       />
@@ -466,6 +467,18 @@ interface TrackWithStations extends TrackInfo {
   station_ids: number[]
 }
 
+interface Props {
+  algorithmMode?: 'all' | 'multi_source' | 'single_source'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  algorithmMode: 'all',
+})
+
+const emit = defineEmits<{
+  start: []
+}>()
+
 const store = useErrorAnalysisStore()
 const appStore = useAppStore()
 
@@ -801,6 +814,7 @@ async function handleStartAnalysis() {
 
     await store.createAnalysis()
     appStore.success('分析任务已创建')
+    emit('start')
   } catch (error: any) {
     appStore.error(error.message || '创建分析任务失败')
   }

--- a/frontend/src/components/errorAnalysis/__tests__/AlgorithmSelector.spec.ts
+++ b/frontend/src/components/errorAnalysis/__tests__/AlgorithmSelector.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import AlgorithmSelector from '../AlgorithmSelector.vue'
+
+const MULTI_SOURCE_ALGORITHMS = [
+  { name: 'mrra', display_name: 'MRRA', version: '1.0', description: '', supports_elevation: true },
+  { name: 'ransac', display_name: 'RANSAC', version: '1.0', description: '', supports_elevation: false },
+  { name: 'weighted_lstsq', display_name: '加权最小二乘', version: '1.0', description: '', supports_elevation: false },
+  { name: 'ransac_heuristic', display_name: 'RANSAC启发式', version: '1.0', description: '', supports_elevation: false },
+]
+
+const SINGLE_SOURCE_ALGORITHMS = [
+  { name: 'kalman', display_name: '卡尔曼滤波', version: '1.0', description: '', supports_elevation: false },
+  { name: 'particle_filter', display_name: '粒子滤波', version: '1.0', description: '', supports_elevation: false },
+  { name: 'spline', display_name: '样条插值', version: '1.0', description: '', supports_elevation: false },
+]
+
+const ALL_ALGORITHMS = [...MULTI_SOURCE_ALGORITHMS, ...SINGLE_SOURCE_ALGORITHMS]
+
+vi.mock('@/stores/errorAnalysis', () => ({
+  useErrorAnalysisStore: vi.fn(() => ({
+    availableAlgorithms: ALL_ALGORITHMS,
+    currentPresets: [],
+    currentConfigSchema: null,
+    selectedAlgorithm: null,
+    loadAlgorithms: vi.fn().mockResolvedValue(undefined),
+    loadAlgorithmConfigSchema: vi.fn().mockResolvedValue(undefined),
+    loadAlgorithmPresets: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+describe('AlgorithmSelector 算法过滤', () => {
+  let wrapper: VueWrapper<any>
+
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  async function mountSelector(mode?: 'all' | 'multi_source' | 'single_source') {
+    wrapper = mount(AlgorithmSelector, {
+      props: { mode },
+      global: { plugins: [createPinia()] },
+    })
+    await wrapper.vm.$nextTick()
+  }
+
+  it('mode=multi_source 只显示多源算法', async () => {
+    await mountSelector('multi_source')
+    const options = wrapper.findAll('select option')
+    const values = options.map(o => o.attributes('value')).filter(v => v !== '')
+    expect(values).toEqual(expect.arrayContaining(['mrra', 'ransac', 'weighted_lstsq', 'ransac_heuristic']))
+    expect(values).not.toContain('kalman')
+    expect(values).not.toContain('particle_filter')
+    expect(values).not.toContain('spline')
+  })
+
+  it('mode=single_source 只显示单源算法', async () => {
+    await mountSelector('single_source')
+    const options = wrapper.findAll('select option')
+    const values = options.map(o => o.attributes('value')).filter(v => v !== '')
+    expect(values).toEqual(expect.arrayContaining(['kalman', 'particle_filter', 'spline']))
+    expect(values).not.toContain('mrra')
+    expect(values).not.toContain('ransac')
+  })
+
+  it('mode=all 显示全部算法', async () => {
+    await mountSelector('all')
+    const options = wrapper.findAll('select option')
+    const values = options.map(o => o.attributes('value')).filter(v => v !== '')
+    expect(values.length).toBe(ALL_ALGORITHMS.length)
+  })
+
+  it('默认 mode=all', async () => {
+    await mountSelector()
+    const options = wrapper.findAll('select option')
+    const values = options.map(o => o.attributes('value')).filter(v => v !== '')
+    expect(values.length).toBe(ALL_ALGORITHMS.length)
+  })
+})

--- a/frontend/src/router/__tests__/routes.spec.ts
+++ b/frontend/src/router/__tests__/routes.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import routes from '../routes'
+
+describe('路由配置', () => {
+  function findRoute(path: string) {
+    return routes.find(r => r.path === path)
+  }
+
+  it('/error-analysis 重定向到多源分析', () => {
+    const route = findRoute('/error-analysis')
+    expect(route).toBeDefined()
+    expect(route!.redirect).toBe('/error-analysis/multi-source')
+  })
+
+  it('/error-analysis/multi-source 指向 MultiSourceAnalysis', () => {
+    const route = findRoute('/error-analysis/multi-source')
+    expect(route).toBeDefined()
+    expect(route!.name).toBe('MultiSourceAnalysis')
+    expect(route!.meta?.title).toContain('多源')
+  })
+
+  it('/error-analysis/single-source 指向 SingleSourceAnalysis', () => {
+    const route = findRoute('/error-analysis/single-source')
+    expect(route).toBeDefined()
+    expect(route!.name).toBe('SingleSourceAnalysis')
+    expect(route!.meta?.title).toContain('单源')
+  })
+
+  it('/error-analysis/tasks 指向 TaskManagement', () => {
+    const route = findRoute('/error-analysis/tasks')
+    expect(route).toBeDefined()
+    expect(route!.name).toBe('TaskManagement')
+    expect(route!.meta?.title).toContain('任务')
+  })
+
+  it('/error-analysis/history/:taskId 指向 ErrorAnalysisHistory', () => {
+    const route = findRoute('/error-analysis/history/:taskId')
+    expect(route).toBeDefined()
+    expect(route!.name).toBe('ErrorAnalysisHistory')
+  })
+
+  it('/error-analysis/smoothed/:taskId 指向 SmoothedTrajectoryHistory', () => {
+    const route = findRoute('/error-analysis/smoothed/:taskId')
+    expect(route).toBeDefined()
+    expect(route!.name).toBe('SmoothedTrajectoryHistory')
+  })
+
+  it('误差分析路由总数为 6', () => {
+    const errorRoutes = routes.filter(r => r.path.startsWith('/error-analysis'))
+    expect(errorRoutes.length).toBe(6)
+  })
+})

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -61,11 +61,28 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/Analysis.vue'),
     meta: { title: 'AI Analysis' },
   },
+  // 误差分析 - 新路由结构
   {
     path: '/error-analysis',
-    name: 'ErrorAnalysis',
-    component: () => import('@/views/ErrorAnalysis.vue'),
-    meta: { title: '误差分析' },
+    redirect: '/error-analysis/multi-source',
+  },
+  {
+    path: '/error-analysis/multi-source',
+    name: 'MultiSourceAnalysis',
+    component: () => import('@/views/MultiSourceAnalysis.vue'),
+    meta: { title: '多源参考分析' },
+  },
+  {
+    path: '/error-analysis/single-source',
+    name: 'SingleSourceAnalysis',
+    component: () => import('@/views/SingleSourceAnalysis.vue'),
+    meta: { title: '单源盲测分析' },
+  },
+  {
+    path: '/error-analysis/tasks',
+    name: 'TaskManagement',
+    component: () => import('@/views/TaskManagement.vue'),
+    meta: { title: '任务管理', requiresAuth: true },
   },
   {
     path: '/error-analysis/history/:taskId',

--- a/frontend/src/stores/__tests__/errorAnalysis.spec.ts
+++ b/frontend/src/stores/__tests__/errorAnalysis.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
+
+describe('ErrorAnalysisStore 算法模式', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('初始状态为 multi_source（无算法选中）', () => {
+    const store = useErrorAnalysisStore()
+    expect(store.isSingleSourceMode).toBe(false)
+    expect(store.isMultiSourceMode).toBe(true)
+  })
+
+  it('选择 kalman 后切换为 single_source', async () => {
+    const store = useErrorAnalysisStore()
+    store.availableAlgorithms = [
+      { name: 'kalman', display_name: '卡尔曼', version: '1.0', description: '', supports_elevation: false },
+    ] as any
+    store.selectedAlgorithm = { name: 'kalman' } as any
+    expect(store.isSingleSourceMode).toBe(true)
+    expect(store.isMultiSourceMode).toBe(false)
+  })
+
+  it('选择 mrra 后为 multi_source', () => {
+    const store = useErrorAnalysisStore()
+    store.selectedAlgorithm = { name: 'mrra' } as any
+    expect(store.isSingleSourceMode).toBe(false)
+    expect(store.algorithmMode).toBe('multi_source')
+  })
+
+  it('选择 particle_filter 后为 single_source', () => {
+    const store = useErrorAnalysisStore()
+    store.selectedAlgorithm = { name: 'particle_filter' } as any
+    expect(store.isSingleSourceMode).toBe(true)
+    expect(store.algorithmMode).toBe('single_source')
+  })
+
+  it('选择 spline 后为 single_source', () => {
+    const store = useErrorAnalysisStore()
+    store.selectedAlgorithm = { name: 'spline' } as any
+    expect(store.isSingleSourceMode).toBe(true)
+  })
+
+  it('选择 ransac 后为 multi_source', () => {
+    const store = useErrorAnalysisStore()
+    store.selectedAlgorithm = { name: 'ransac' } as any
+    expect(store.isSingleSourceMode).toBe(false)
+    expect(store.algorithmMode).toBe('multi_source')
+  })
+})

--- a/frontend/src/stores/errorAnalysis.ts
+++ b/frontend/src/stores/errorAnalysis.ts
@@ -275,7 +275,6 @@ export const useErrorAnalysisStore = defineStore('errorAnalysis', () => {
   function applyPreset(preset: PresetProfile) {
     const presetConfig = PRESET_PROFILES[preset]
     console.log('[Store] applyPreset called with:', preset)
-    console.log('[Store] presetConfig:', JSON.stringify(presetConfig))
     if (presetConfig) {
       // 创建新对象并替换，确保触发响应式更新
       const newConfig = {
@@ -288,9 +287,7 @@ export const useErrorAnalysisStore = defineStore('errorAnalysis', () => {
         cost_weights: { ...presetConfig.cost_weights },
         max_match_groups: presetConfig.max_match_groups,
       }
-      console.log('[Store] newConfig to apply:', JSON.stringify(newConfig))
       config.value = newConfig
-      console.log('[Store] config.value after assignment:', JSON.stringify(config.value))
     }
   }
 

--- a/frontend/src/views/ErrorAnalysisHistory.vue
+++ b/frontend/src/views/ErrorAnalysisHistory.vue
@@ -393,7 +393,7 @@ const singleSourceTabs = [
 
 // 根据模式获取标签页
 const tabs = computed(() => {
-  return isSingleSourceMode.value ? singleSourceTabs.value : multiSourceTabs
+  return isSingleSourceMode.value ? singleSourceTabs : multiSourceTabs
 })
 
 const statusInfo = computed(() => {

--- a/frontend/src/views/ErrorAnalysisHistory.vue
+++ b/frontend/src/views/ErrorAnalysisHistory.vue
@@ -456,7 +456,7 @@ function getStepData(stepIndex: number): Record<string, unknown> {
 }
 
 function goBack() {
-  router.push('/error-analysis')
+  router.push('/error-analysis/tasks')
 }
 
 async function loadData() {

--- a/frontend/src/views/MultiSourceAnalysis.vue
+++ b/frontend/src/views/MultiSourceAnalysis.vue
@@ -25,8 +25,8 @@
       </div>
 
       <div class="mode-switch">
-        <router-link to="/error-analysis/multi-source" class="mode-tab active">多源参考</router-link>
-        <router-link to="/error-analysis/single-source" class="mode-tab">单源盲测</router-link>
+        <router-link to="/error-analysis/multi-source" class="mode-tab" active-class="active">多源参考</router-link>
+        <router-link to="/error-analysis/single-source" class="mode-tab" active-class="active">单源盲测</router-link>
       </div>
 
       <div class="main-content">

--- a/frontend/src/views/MultiSourceAnalysis.vue
+++ b/frontend/src/views/MultiSourceAnalysis.vue
@@ -1,0 +1,375 @@
+<template>
+  <div class="error-analysis-page">
+    <AppHeader />
+
+    <div class="error-analysis-container">
+      <div class="page-header">
+        <div>
+          <h1 class="page-title">多源参考分析</h1>
+          <p class="page-subtitle">{{ store.currentAlgorithmName }}</p>
+        </div>
+        <div class="header-actions">
+          <router-link to="/error-analysis/tasks" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            任务管理
+          </router-link>
+          <router-link to="/data" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+            </svg>
+            上传数据
+          </router-link>
+        </div>
+      </div>
+
+      <div class="mode-switch">
+        <router-link to="/error-analysis/multi-source" class="mode-tab active">多源参考</router-link>
+        <router-link to="/error-analysis/single-source" class="mode-tab">单源盲测</router-link>
+      </div>
+
+      <div class="main-content">
+        <div class="config-panel-wrapper">
+          <ErrorConfigPanel
+            :algorithm-mode="'multi_source'"
+            @start="handleAnalysisStart"
+          />
+        </div>
+
+        <div class="content-panel-wrapper">
+          <div v-if="store.currentTask" class="progress-section">
+            <ErrorProgressBar
+              :status="store.currentTask.status"
+              :progress="store.taskProgress"
+              :error="store.currentTask.error_message"
+            />
+          </div>
+
+          <div v-if="!store.currentTask" class="empty-section">
+            <EmptyState
+              title="开始多源参考分析"
+              description="选择雷达站和航迹数据，配置分析参数后开始误差分析"
+            >
+              <template #icon>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+                </svg>
+              </template>
+            </EmptyState>
+          </div>
+
+          <div v-else-if="store.isTaskCompleted" class="results-section">
+            <div class="tabs">
+              <button
+                v-for="tab in tabs"
+                :key="tab.key"
+                class="tab-btn"
+                :class="{ active: activeTab === tab.key }"
+                @click="activeTab = tab.key"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path v-if="tab.key === 'chart'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"/>
+                  <path v-else-if="tab.key === 'table'" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+                  <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                </svg>
+                {{ tab.label }}
+              </button>
+            </div>
+
+            <div v-if="activeTab === 'chart'" class="tab-content">
+              <ErrorResultChart
+                :chart-data="store.chartData"
+                :loading="store.chartDataLoading"
+              />
+            </div>
+
+            <div v-else-if="activeTab === 'table'" class="tab-content">
+              <ErrorTable
+                v-if="store.analysisResult"
+                :results="store.analysisResult.errors"
+                :loading="store.resultLoading"
+              />
+            </div>
+
+            <div v-else-if="activeTab === 'matches'" class="tab-content">
+              <MatchVisualization
+                :match-groups="store.matchGroups"
+                :segments="store.segments"
+                :loading="store.matchGroupsLoading"
+                :total-groups="store.matchGroupsTotal"
+                @segment-change="handleSegmentChange"
+              />
+            </div>
+          </div>
+
+          <div v-else-if="store.isTaskFailed" class="error-section">
+            <div class="error-card">
+              <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+              </svg>
+              <h3>分析失败</h3>
+              <p>{{ store.currentTask?.error_message || '未知错误' }}</p>
+              <button class="btn btn-primary" @click="handleRetry">重新开始</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onUnmounted } from 'vue'
+import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
+import { useAppStore } from '@/stores/app'
+import EmptyState from '@/components/EmptyState.vue'
+import AppHeader from '@/components/AppHeader.vue'
+import ErrorConfigPanel from '@/components/errorAnalysis/ErrorConfigPanel.vue'
+import ErrorProgressBar from '@/components/errorAnalysis/ErrorProgressBar.vue'
+import ErrorResultChart from '@/components/errorAnalysis/ErrorResultChart.vue'
+import ErrorTable from '@/components/errorAnalysis/ErrorTable.vue'
+import MatchVisualization from '@/components/errorAnalysis/MatchVisualization.vue'
+
+const store = useErrorAnalysisStore()
+const appStore = useAppStore()
+
+const activeTab = ref<'chart' | 'table' | 'matches'>('chart')
+
+const tabs = [
+  { key: 'chart' as const, label: '图表' },
+  { key: 'table' as const, label: '详细数据' },
+  { key: 'matches' as const, label: '匹配组' },
+]
+
+function handleAnalysisStart() {
+  activeTab.value = 'chart'
+}
+
+function handleRetry() {
+  store.clearCurrentTask()
+}
+
+async function handleSegmentChange(segmentId: number | null) {
+  if (store.currentTask) {
+    await store.loadMatchGroups(store.currentTask.task_id, {
+      segment_id: segmentId ?? undefined,
+      skip: 0,
+      limit: 100,
+    })
+  }
+}
+
+onUnmounted(() => {
+  store.stopPolling()
+})
+</script>
+
+<style scoped>
+.error-analysis-page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+
+.error-analysis-container {
+  padding: 1.5rem;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9375rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.mode-switch {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  background: var(--bg-secondary);
+  border-radius: 0.5rem;
+  padding: 0.25rem;
+  width: fit-content;
+}
+
+.mode-tab {
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.mode-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.mode-tab.active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.main-content {
+  display: grid;
+  grid-template-columns: 350px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.config-panel-wrapper {
+  position: sticky;
+  top: 5rem;
+}
+
+.content-panel-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.progress-section {
+  margin-bottom: -0.5rem;
+}
+
+.empty-section,
+.results-section,
+.error-section {
+  padding: 1rem 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: var(--bg-secondary);
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.tab-btn.active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.tab-btn svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.tab-content {
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.error-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 2rem;
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.error-icon {
+  width: 4rem;
+  height: 4rem;
+  color: #ef4444;
+}
+
+.error-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.error-card p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn svg { width: 1rem; height: 1rem; }
+
+.btn-primary { background: var(--color-primary); color: white; }
+.btn-primary:hover { background: #2563eb; }
+
+.btn-secondary { background: var(--bg-secondary); color: var(--text-primary); }
+.btn-secondary:hover { background: var(--bg-tertiary); }
+
+@media (max-width: 1024px) {
+  .main-content { grid-template-columns: 1fr; }
+  .config-panel-wrapper { position: static; }
+}
+
+@media (max-width: 640px) {
+  .error-analysis-container { padding: 1rem; }
+  .page-header { flex-direction: column; align-items: flex-start; }
+  .tabs { overflow-x: auto; }
+}
+</style>

--- a/frontend/src/views/MultiSourceAnalysis.vue
+++ b/frontend/src/views/MultiSourceAnalysis.vue
@@ -38,7 +38,7 @@
         </div>
 
         <div class="content-panel-wrapper">
-          <div v-if="store.currentTask" class="progress-section">
+          <div v-if="store.currentTask && !store.isTaskCompleted && !store.isTaskFailed" class="progress-section">
             <ErrorProgressBar
               :status="store.currentTask.status"
               :progress="store.taskProgress"
@@ -122,7 +122,6 @@
 <script setup lang="ts">
 import { ref, onUnmounted } from 'vue'
 import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
-import { useAppStore } from '@/stores/app'
 import EmptyState from '@/components/EmptyState.vue'
 import AppHeader from '@/components/AppHeader.vue'
 import ErrorConfigPanel from '@/components/errorAnalysis/ErrorConfigPanel.vue'
@@ -132,7 +131,6 @@ import ErrorTable from '@/components/errorAnalysis/ErrorTable.vue'
 import MatchVisualization from '@/components/errorAnalysis/MatchVisualization.vue'
 
 const store = useErrorAnalysisStore()
-const appStore = useAppStore()
 
 const activeTab = ref<'chart' | 'table' | 'matches'>('chart')
 

--- a/frontend/src/views/SingleSourceAnalysis.vue
+++ b/frontend/src/views/SingleSourceAnalysis.vue
@@ -1,0 +1,280 @@
+<template>
+  <div class="error-analysis-page">
+    <AppHeader />
+
+    <div class="error-analysis-container">
+      <div class="page-header">
+        <div>
+          <h1 class="page-title">单源盲测分析</h1>
+          <p class="page-subtitle">{{ store.currentAlgorithmName }}</p>
+        </div>
+        <div class="header-actions">
+          <router-link to="/error-analysis/tasks" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            任务管理
+          </router-link>
+          <router-link to="/data" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+            </svg>
+            上传数据
+          </router-link>
+        </div>
+      </div>
+
+      <div class="mode-switch">
+        <router-link to="/error-analysis/multi-source" class="mode-tab">多源参考</router-link>
+        <router-link to="/error-analysis/single-source" class="mode-tab active">单源盲测</router-link>
+      </div>
+
+      <div class="main-content">
+        <div class="config-panel-wrapper">
+          <ErrorConfigPanel
+            :algorithm-mode="'single_source'"
+            @start="handleAnalysisStart"
+          />
+        </div>
+
+        <div class="content-panel-wrapper">
+          <div v-if="store.currentTask" class="progress-section">
+            <ErrorProgressBar
+              :status="store.currentTask.status"
+              :progress="store.taskProgress"
+              :error="store.currentTask.error_message"
+            />
+          </div>
+
+          <div v-if="!store.currentTask" class="empty-section">
+            <EmptyState
+              title="开始单源盲测分析"
+              description="选择一个雷达站和一条目标航迹，配置平滑参数后开始轨迹平滑处理"
+            >
+              <template #icon>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                </svg>
+              </template>
+            </EmptyState>
+          </div>
+
+          <div v-else-if="store.isTaskCompleted && store.taskDetail" class="results-section">
+            <SmoothedTrajectoryView
+              v-if="store.taskDetail.smoothed_trajectories.length > 0"
+              :trajectories="store.taskDetail.smoothed_trajectories"
+            />
+            <div v-else class="empty-result">
+              <p>分析完成，但未生成平滑轨迹数据</p>
+            </div>
+          </div>
+
+          <div v-else-if="store.isTaskFailed" class="error-section">
+            <div class="error-card">
+              <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+              </svg>
+              <h3>分析失败</h3>
+              <p>{{ store.currentTask?.error_message || '未知错误' }}</p>
+              <button class="btn btn-primary" @click="handleRetry">重新开始</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
+import EmptyState from '@/components/EmptyState.vue'
+import AppHeader from '@/components/AppHeader.vue'
+import ErrorConfigPanel from '@/components/errorAnalysis/ErrorConfigPanel.vue'
+import ErrorProgressBar from '@/components/errorAnalysis/ErrorProgressBar.vue'
+import SmoothedTrajectoryView from '@/components/errorAnalysis/SmoothedTrajectoryView.vue'
+
+const store = useErrorAnalysisStore()
+
+function handleAnalysisStart() {
+  // no-op, results render automatically when completed
+}
+
+function handleRetry() {
+  store.clearCurrentTask()
+}
+
+onUnmounted(() => {
+  store.stopPolling()
+})
+</script>
+
+<style scoped>
+.error-analysis-page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+
+.error-analysis-container {
+  padding: 1.5rem;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9375rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.mode-switch {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  background: var(--bg-secondary);
+  border-radius: 0.5rem;
+  padding: 0.25rem;
+  width: fit-content;
+}
+
+.mode-tab {
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.mode-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.mode-tab.active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.main-content {
+  display: grid;
+  grid-template-columns: 350px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.config-panel-wrapper {
+  position: sticky;
+  top: 5rem;
+}
+
+.content-panel-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.progress-section {
+  margin-bottom: -0.5rem;
+}
+
+.empty-section,
+.results-section,
+.error-section {
+  padding: 1rem 0;
+}
+
+.empty-result {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+}
+
+.error-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 2rem;
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.error-icon {
+  width: 4rem;
+  height: 4rem;
+  color: #ef4444;
+}
+
+.error-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.error-card p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn svg { width: 1rem; height: 1rem; }
+
+.btn-primary { background: var(--color-primary); color: white; }
+.btn-primary:hover { background: #2563eb; }
+
+.btn-secondary { background: var(--bg-secondary); color: var(--text-primary); }
+.btn-secondary:hover { background: var(--bg-tertiary); }
+
+@media (max-width: 1024px) {
+  .main-content { grid-template-columns: 1fr; }
+  .config-panel-wrapper { position: static; }
+}
+
+@media (max-width: 640px) {
+  .error-analysis-container { padding: 1rem; }
+  .page-header { flex-direction: column; align-items: flex-start; }
+}
+</style>

--- a/frontend/src/views/SingleSourceAnalysis.vue
+++ b/frontend/src/views/SingleSourceAnalysis.vue
@@ -25,8 +25,8 @@
       </div>
 
       <div class="mode-switch">
-        <router-link to="/error-analysis/multi-source" class="mode-tab">多源参考</router-link>
-        <router-link to="/error-analysis/single-source" class="mode-tab active">单源盲测</router-link>
+        <router-link to="/error-analysis/multi-source" class="mode-tab" active-class="active">多源参考</router-link>
+        <router-link to="/error-analysis/single-source" class="mode-tab" active-class="active">单源盲测</router-link>
       </div>
 
       <div class="main-content">
@@ -86,8 +86,9 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted } from 'vue'
+import { watch, onUnmounted } from 'vue'
 import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
+import { useAppStore } from '@/stores/app'
 import EmptyState from '@/components/EmptyState.vue'
 import AppHeader from '@/components/AppHeader.vue'
 import ErrorConfigPanel from '@/components/errorAnalysis/ErrorConfigPanel.vue'
@@ -95,6 +96,7 @@ import ErrorProgressBar from '@/components/errorAnalysis/ErrorProgressBar.vue'
 import SmoothedTrajectoryView from '@/components/errorAnalysis/SmoothedTrajectoryView.vue'
 
 const store = useErrorAnalysisStore()
+const appStore = useAppStore()
 
 function handleAnalysisStart() {
   // no-op, results render automatically when completed
@@ -103,6 +105,16 @@ function handleAnalysisStart() {
 function handleRetry() {
   store.clearCurrentTask()
 }
+
+watch(() => store.isTaskCompleted, async (completed) => {
+  if (completed && store.currentTask) {
+    try {
+      await store.loadTaskDetailFull(store.currentTask.task_id, true, false)
+    } catch (e: any) {
+      appStore.error(e.message || '加载任务详情失败')
+    }
+  }
+})
 
 onUnmounted(() => {
   store.stopPolling()

--- a/frontend/src/views/SingleSourceAnalysis.vue
+++ b/frontend/src/views/SingleSourceAnalysis.vue
@@ -38,7 +38,7 @@
         </div>
 
         <div class="content-panel-wrapper">
-          <div v-if="store.currentTask" class="progress-section">
+          <div v-if="store.currentTask && !store.isTaskCompleted && !store.isTaskFailed" class="progress-section">
             <ErrorProgressBar
               :status="store.currentTask.status"
               :progress="store.taskProgress"

--- a/frontend/src/views/SmoothedTrajectoryHistory.vue
+++ b/frontend/src/views/SmoothedTrajectoryHistory.vue
@@ -246,7 +246,7 @@ const avgRmseAlt = computed(() => {
 })
 
 function goBack() {
-  router.push('/error-analysis')
+  router.push('/error-analysis/tasks')
 }
 
 async function loadData() {

--- a/frontend/src/views/TaskManagement.vue
+++ b/frontend/src/views/TaskManagement.vue
@@ -1,0 +1,638 @@
+<template>
+  <div class="task-management-page">
+    <AppHeader />
+
+    <div class="task-management-container">
+      <div class="page-header">
+        <div>
+          <h1 class="page-title">任务管理</h1>
+          <p class="page-subtitle">所有误差分析任务历史记录</p>
+        </div>
+        <div class="header-actions">
+          <router-link to="/error-analysis/multi-source" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+            </svg>
+            多源分析
+          </router-link>
+          <router-link to="/error-analysis/single-source" class="btn btn-secondary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+            </svg>
+            单源分析
+          </router-link>
+        </div>
+      </div>
+
+      <!-- 筛选栏 -->
+      <div class="filter-bar">
+        <div class="filter-group">
+          <label class="filter-label">算法类型</label>
+          <select v-model="filterAlgorithmType" class="filter-select" @change="loadTasks">
+            <option value="all">全部</option>
+            <option value="multi_source">多源参考</option>
+            <option value="single_source">单源盲测</option>
+          </select>
+        </div>
+        <div class="filter-group">
+          <label class="filter-label">任务状态</label>
+          <select v-model="filterStatus" class="filter-select" @change="loadTasks">
+            <option value="">全部</option>
+            <option value="pending">等待中</option>
+            <option value="extracting">提取航迹</option>
+            <option value="interpolating">航迹插值</option>
+            <option value="matching">航迹匹配</option>
+            <option value="calculating">计算误差</option>
+            <option value="completed">已完成</option>
+            <option value="failed">失败</option>
+          </select>
+        </div>
+        <button class="btn btn-secondary btn-sm" @click="loadTasks">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="14" height="14">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+          </svg>
+          刷新
+        </button>
+      </div>
+
+      <!-- 加载状态 -->
+      <div v-if="store.taskListLoading" class="loading-state">
+        <div class="loading-spinner"></div>
+        <p>加载任务列表...</p>
+      </div>
+
+      <!-- 任务列表 -->
+      <div v-else-if="filteredTasks.length > 0" class="task-list">
+        <div
+          v-for="task in filteredTasks"
+          :key="task.id"
+          class="task-card"
+          @click="viewTaskDetail(task)"
+        >
+          <div class="task-left">
+            <div class="task-status-icon" :class="`status-${task.status}`">
+              <svg v-if="task.status === 'completed'" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+              </svg>
+              <svg v-else-if="task.status === 'failed'" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+              </svg>
+              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <circle cx="12" cy="12" r="10" stroke-width="2"/>
+                <path fill="none" stroke="currentColor" stroke-width="2" d="M12 2a10 10 0 0 1 10 10">
+                  <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="1s" repeatCount="indefinite"/>
+                </path>
+              </svg>
+            </div>
+            <div class="task-info">
+              <div class="task-title-row">
+                <span class="task-id">任务 #{{ task.id }}</span>
+                <span class="task-type-badge" :class="getAlgorithmType(task.algorithm_name)">
+                  {{ isSingleSourceAlgorithm(task.algorithm_name) ? '单源盲测' : '多源参考' }}
+                </span>
+              </div>
+              <div class="task-meta">
+                <span class="task-algorithm">{{ task.algorithm_name || '--' }}</span>
+                <span class="task-time">{{ formatTime(task.created_at) }}</span>
+              </div>
+              <div class="task-details">
+                <span class="detail-chip">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="12" height="12">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                  </svg>
+                  {{ task.radar_station_ids?.length || 0 }} 站
+                </span>
+                <span class="detail-chip">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" width="12" height="12">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+                  </svg>
+                  {{ task.track_ids?.length || 0 }} 轨迹
+                </span>
+              </div>
+            </div>
+          </div>
+          <div class="task-right">
+            <span class="status-label" :class="`label-${task.status}`">
+              {{ getStatusLabel(task.status) }}
+            </span>
+            <div v-if="isTaskProcessing(task.status)" class="task-progress">
+              <div class="progress-bar">
+                <div class="progress-fill" :style="{ width: `${task.progress || 0}%` }"></div>
+              </div>
+              <span class="progress-text">{{ task.progress || 0 }}%</span>
+            </div>
+            <button
+              v-if="task.status === 'completed'"
+              class="btn btn-primary btn-sm"
+              @click.stop="viewTaskDetail(task)"
+            >
+              查看详情
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 空状态 -->
+      <div v-else class="empty-state">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+        </svg>
+        <h3>暂无任务记录</h3>
+        <p>开始一次分析来创建第一个任务</p>
+        <div class="empty-actions">
+          <router-link to="/error-analysis/multi-source" class="btn btn-primary">
+            多源参考分析
+          </router-link>
+          <router-link to="/error-analysis/single-source" class="btn btn-secondary">
+            单源盲测分析
+          </router-link>
+        </div>
+      </div>
+
+      <!-- 分页 -->
+      <div v-if="totalPages > 1" class="pagination">
+        <button
+          class="btn btn-secondary btn-sm"
+          :disabled="currentPage <= 1"
+          @click="currentPage--; loadTasks()"
+        >
+          上一页
+        </button>
+        <span class="page-info">{{ currentPage }} / {{ totalPages }}</span>
+        <button
+          class="btn btn-secondary btn-sm"
+          :disabled="currentPage >= totalPages"
+          @click="currentPage++; loadTasks()"
+        >
+          下一页
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useErrorAnalysisStore } from '@/stores/errorAnalysis'
+import { useAppStore } from '@/stores/app'
+import type { ErrorAnalysisTask } from '@/types/errorAnalysis'
+import AppHeader from '@/components/AppHeader.vue'
+
+const SINGLE_SOURCE_ALGORITHMS = ['kalman', 'particle_filter', 'spline']
+
+const router = useRouter()
+const store = useErrorAnalysisStore()
+const appStore = useAppStore()
+
+const filterAlgorithmType = ref<'all' | 'multi_source' | 'single_source'>('all')
+const filterStatus = ref('')
+const currentPage = ref(1)
+const pageSize = 20
+
+function isSingleSourceAlgorithm(name?: string): boolean {
+  return !!name && SINGLE_SOURCE_ALGORITHMS.includes(name)
+}
+
+function getAlgorithmType(name?: string): string {
+  return isSingleSourceAlgorithm(name) ? 'single_source' : 'multi_source'
+}
+
+const filteredTasks = computed(() => {
+  let tasks = store.taskList
+  if (filterAlgorithmType.value !== 'all') {
+    tasks = tasks.filter(t => {
+      const isSingle = isSingleSourceAlgorithm(t.algorithm_name)
+      return filterAlgorithmType.value === 'single_source' ? isSingle : !isSingle
+    })
+  }
+  return tasks
+})
+
+const totalPages = computed(() => Math.ceil(store.taskListTotal / pageSize))
+
+function isTaskProcessing(status: string): boolean {
+  return ['pending', 'extracting', 'interpolating', 'matching', 'calculating'].includes(status)
+}
+
+function getStatusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    pending: '等待中',
+    extracting: '提取航迹',
+    interpolating: '航迹插值',
+    matching: '航迹匹配',
+    calculating: '计算误差',
+    completed: '已完成',
+    failed: '失败',
+  }
+  return labels[status] || status
+}
+
+function formatTime(dateString: string): string {
+  if (!dateString) return '--'
+  const date = new Date(dateString)
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function viewTaskDetail(task: ErrorAnalysisTask) {
+  if (task.status !== 'completed') return
+  const isSingle = isSingleSourceAlgorithm(task.algorithm_name)
+  if (isSingle) {
+    router.push(`/error-analysis/smoothed/${task.task_id}`)
+  } else {
+    router.push(`/error-analysis/history/${task.task_id}`)
+  }
+}
+
+async function loadTasks() {
+  try {
+    await store.loadTaskList({
+      skip: (currentPage.value - 1) * pageSize,
+      limit: pageSize,
+      status: filterStatus.value || undefined,
+    })
+  } catch (error: any) {
+    appStore.error(error.message || '加载任务列表失败')
+  }
+}
+
+onMounted(() => {
+  loadTasks()
+})
+</script>
+
+<style scoped>
+.task-management-page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+
+.task-management-container {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9375rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+/* 筛选栏 */
+.filter-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.filter-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.filter-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.375rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+/* 任务列表 */
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+}
+
+.task-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1);
+}
+
+.task-card:hover:not(:has(.task-right .btn:hover)) {
+  background: var(--bg-tertiary);
+}
+
+.task-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.task-status-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.task-status-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.task-status-icon.status-completed { background: rgba(16, 185, 129, 0.1); color: #10b981; }
+.task-status-icon.status-failed { background: rgba(239, 68, 68, 0.1); color: #ef4444; }
+.task-status-icon.status-pending,
+.task-status-icon.status-extracting,
+.task-status-icon.status-interpolating,
+.task-status-icon.status-matching,
+.task-status-icon.status-calculating {
+  background: rgba(59, 130, 246, 0.1); color: #3b82f6;
+}
+
+.task-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task-id {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+}
+
+.task-type-badge {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 1rem;
+  font-weight: 500;
+}
+
+.task-type-badge.multi_source {
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
+.task-type-badge.single_source {
+  background: rgba(139, 92, 246, 0.1);
+  color: #8b5cf6;
+}
+
+.task-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.375rem;
+}
+
+.task-algorithm {
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.5rem;
+  background: var(--bg-tertiary);
+  border-radius: 0.25rem;
+  color: var(--text-secondary);
+  font-family: monospace;
+}
+
+.task-time {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.task-details {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+}
+
+.detail-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.task-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.status-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+}
+
+.status-label.label-completed { background: rgba(16, 185, 129, 0.1); color: #10b981; }
+.status-label.label-failed { background: rgba(239, 68, 68, 0.1); color: #ef4444; }
+.status-label.label-pending,
+.status-label.label-extracting,
+.status-label.label-interpolating,
+.status-label.label-matching,
+.status-label.label-calculating {
+  background: rgba(59, 130, 246, 0.1); color: #3b82f6;
+}
+
+.task-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 120px;
+}
+
+.progress-bar {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: 2px;
+  transition: width 0.3s;
+}
+
+.progress-text {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  min-width: 2rem;
+  text-align: right;
+}
+
+/* 空状态 */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+  background: var(--bg-secondary);
+  border-radius: 0.75rem;
+  text-align: center;
+}
+
+.empty-state svg {
+  width: 3rem;
+  height: 3rem;
+  color: var(--text-muted);
+}
+
+.empty-state h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.empty-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+/* 加载 */
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+}
+
+.loading-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-state p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* 分页 */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.page-info {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+/* 按钮 */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn svg { width: 1rem; height: 1rem; }
+
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-sm { padding: 0.375rem 0.75rem; font-size: 0.8125rem; }
+
+.btn-primary { background: var(--color-primary); color: white; }
+.btn-primary:hover { background: #2563eb; }
+
+.btn-secondary { background: var(--bg-secondary); color: var(--text-primary); }
+.btn-secondary:hover { background: var(--bg-tertiary); }
+
+@media (max-width: 768px) {
+  .task-card { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+  .task-right { flex-direction: row; align-items: center; width: 100%; justify-content: space-between; }
+  .filter-bar { flex-direction: column; align-items: stretch; }
+}
+</style>

--- a/frontend/src/views/TaskManagement.vue
+++ b/frontend/src/views/TaskManagement.vue
@@ -36,7 +36,7 @@
         </div>
         <div class="filter-group">
           <label class="filter-label">任务状态</label>
-          <select v-model="filterStatus" class="filter-select" @change="loadTasks">
+          <select v-model="filterStatus" class="filter-select" @change="currentPage = 1; loadTasks()">
             <option value="">全部</option>
             <option value="pending">等待中</option>
             <option value="extracting">提取航迹</option>

--- a/frontend/src/views/TrackVisualization.vue
+++ b/frontend/src/views/TrackVisualization.vue
@@ -206,7 +206,6 @@ const loadFiles = async () => {
 const selectFile = (file: FileItem) => {
   selectedFileId.value = file.id
   // TODO: 加载该文件的轨迹数据进行可视化
-  console.log('选择文件:', file.filename)
 }
 
 // 导航到数据管理页面上传文件

--- a/frontend/src/views/__tests__/taskManagement.spec.ts
+++ b/frontend/src/views/__tests__/taskManagement.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+
+const SINGLE_SOURCE_ALGORITHMS = ['kalman', 'particle_filter', 'spline']
+
+function isSingleSourceAlgorithm(name?: string): boolean {
+  return !!name && SINGLE_SOURCE_ALGORITHMS.includes(name)
+}
+
+function getAlgorithmType(name?: string): string {
+  return isSingleSourceAlgorithm(name) ? 'single_source' : 'multi_source'
+}
+
+describe('TaskManagement 辅助函数', () => {
+  describe('isSingleSourceAlgorithm', () => {
+    it('kalman 是单源算法', () => {
+      expect(isSingleSourceAlgorithm('kalman')).toBe(true)
+    })
+
+    it('particle_filter 是单源算法', () => {
+      expect(isSingleSourceAlgorithm('particle_filter')).toBe(true)
+    })
+
+    it('spline 是单源算法', () => {
+      expect(isSingleSourceAlgorithm('spline')).toBe(true)
+    })
+
+    it('mrra 不是单源算法', () => {
+      expect(isSingleSourceAlgorithm('mrra')).toBe(false)
+    })
+
+    it('ransac 不是单源算法', () => {
+      expect(isSingleSourceAlgorithm('ransac')).toBe(false)
+    })
+
+    it('undefined 返回 false', () => {
+      expect(isSingleSourceAlgorithm(undefined)).toBe(false)
+    })
+
+    it('空字符串返回 false', () => {
+      expect(isSingleSourceAlgorithm('')).toBe(false)
+    })
+
+    it('未知算法名返回 false', () => {
+      expect(isSingleSourceAlgorithm('unknown_algo')).toBe(false)
+    })
+  })
+
+  describe('getAlgorithmType', () => {
+    it('单源算法返回 single_source', () => {
+      expect(getAlgorithmType('kalman')).toBe('single_source')
+      expect(getAlgorithmType('particle_filter')).toBe('single_source')
+      expect(getAlgorithmType('spline')).toBe('single_source')
+    })
+
+    it('多源算法返回 multi_source', () => {
+      expect(getAlgorithmType('mrra')).toBe('multi_source')
+      expect(getAlgorithmType('ransac')).toBe('multi_source')
+      expect(getAlgorithmType('weighted_lstsq')).toBe('multi_source')
+      expect(getAlgorithmType('ransac_heuristic')).toBe('multi_source')
+    })
+
+    it('undefined 默认返回 multi_source', () => {
+      expect(getAlgorithmType(undefined)).toBe('multi_source')
+    })
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,10 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
   plugins: [
     vue(),
     vueDevTools(),


### PR DESCRIPTION
## Issue

Closes #6

## 改动内容

将前端误差分析从单一页面拆分为三个独立页面：

### 新增文件
- **`MultiSourceAnalysis.vue`** (375行) — 多源参考分析页面，含算法选择(mrra/ransac/ransac_heuristic/weighted_lstsq)、配置面板、进度展示、结果展示（图表/详细数据/匹配组）
- **`SingleSourceAnalysis.vue`** (292行) — 单源盲测分析页面，含算法选择(kalman/particle_filter/spline)、配置面板、进度展示、平滑轨迹结果展示
- **`TaskManagement.vue`** (638行) — 任务管理页面，含历史任务列表、按算法类型/状态筛选、分页、点击跳转对应详情页

### 路由重构
- `/error-analysis` → 重定向到 `/error-analysis/multi-source`
- `/error-analysis/multi-source` → MultiSourceAnalysis
- `/error-analysis/single-source` → SingleSourceAnalysis
- `/error-analysis/tasks` → TaskManagement

### 组件改动
- `AlgorithmSelector.vue` — 新增 `mode` prop，按 `multi_source`/`single_source` 过滤算法列表
- `ErrorConfigPanel.vue` — 新增 `algorithmMode` prop 传递给 AlgorithmSelector，新增 `start` emit
- `AppHeader.vue` — 导航从单一"误差分析"拆为"多源分析"/"单源分析"/"任务管理"三个入口

### Bug 修复
- 修复进度条与结果区域同时显示（v-if/v-else-if 链不互斥）
- 修复 TaskManagement 筛选状态变化时页码未重置
- 修复 ErrorAnalysisHistory 中 `singleSourceTabs.value` 误用
- 移除 store 中残留的 debug console.log

### 测试
添加 vitest 配置和 28 个单元测试：
- 路由配置正确性（7 tests）
- AlgorithmSelector 算法过滤逻辑（4 tests）
- TaskManagement 辅助函数（11 tests）
- Store 算法模式计算（6 tests）

## 截图/验证
- TypeScript 类型检查：新文件零错误
- Vite 构建：成功
- 28/28 测试通过